### PR TITLE
Add more tests for Spotify Service layer

### DIFF
--- a/src/__test__/spotifyService.test.js
+++ b/src/__test__/spotifyService.test.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { getUser, getPlaylists } = require("../service/spotifyService.js");
+const { getUser, getPlaylists, getTrackURI } = require("../service/spotifyService.js");
 const { getAuthHeaders } = require("../util/auth.js");
 
 // Mock getAuthHeaders()
@@ -62,6 +62,31 @@ describe("Spotify service layer", () => {
 
             expect(axios.get).toHaveBeenCalledTimes(1);
             expect(getAuthHeaders).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("getTrackURI function", () => {
+        test("Successfully returns a Spotify URI given a track and artist", async () => {
+            // Arrange
+            const mockArtist = "artist";
+            const mockTrack = "track";
+            const mockSpotifyURI = "spotifyId";
+
+            axios.get.mockResolvedValueOnce({
+                data: {
+                    tracks: {
+                        items: [
+                            { uri: mockSpotifyURI }
+                        ]
+                    }
+                }
+            });
+
+            // Act
+            const result = await getTrackURI(mockArtist, mockTrack);
+
+            // Assert
+            expect(result).toBe(mockSpotifyURI);
         });
     });
 });

--- a/src/__test__/spotifyService.test.js
+++ b/src/__test__/spotifyService.test.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { getUser, getPlaylists, getTrackURI } = require("../service/spotifyService.js");
+const { getUser, getPlaylists, getTrackURI, getTokenInfo } = require("../service/spotifyService.js");
 const { getAuthHeaders } = require("../util/auth.js");
 
 // Mock getAuthHeaders()
@@ -87,6 +87,31 @@ describe("Spotify service layer", () => {
 
             // Assert
             expect(result).toBe(mockSpotifyURI);
+
+            expect(axios.get).toHaveBeenCalledTimes(1);
+            expect(getAuthHeaders).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("getTokenInfo function", () => {
+        test("Successfully returns session token info", async () => {
+            // Arrange
+            const mockCode = "code";
+            const mockTokenInfo = {
+                accessToken: "accessToken",
+                refreshToken: "refreshToken",
+                expiresIn: "expiresIn"
+            }
+
+            axios.post.mockResolvedValueOnce({
+                data: mockTokenInfo
+            });
+
+            // Act
+            const result = await getTokenInfo(mockCode);
+
+            // Assert
+            expect(result).toBe(mockTokenInfo);
         });
     });
 });

--- a/src/__test__/spotifyService.test.js
+++ b/src/__test__/spotifyService.test.js
@@ -112,6 +112,7 @@ describe("Spotify service layer", () => {
 
             // Assert
             expect(result).toBe(mockTokenInfo);
+            expect(axios.post).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/__test__/spotifyService.test.js
+++ b/src/__test__/spotifyService.test.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { getUser } = require("../service/spotifyService.js");
+const { getUser, getPlaylists } = require("../service/spotifyService.js");
 const { getAuthHeaders } = require("../util/auth.js");
 
 // Mock getAuthHeaders()
@@ -11,6 +11,10 @@ jest.mock("../util/auth.js", () => ({
 jest.mock("axios");
 
 describe("Spotify service layer", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     describe("getUser function", () => {
         test("Successfully returns user information", async () => {
             // Arrange
@@ -22,6 +26,42 @@ describe("Spotify service layer", () => {
 
             // Assert
             expect(result).toBe(mockUser);
+
+            expect(axios.get).toHaveBeenCalledTimes(1);
+            expect(getAuthHeaders).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("getPlaylists function", () => {
+        test("Successfully returns all current user's playlists", async () => {
+            // Arrange
+            const mockPlaylists = {
+                items: [
+                    {
+                        id: "playlistId 1",
+                        public: true,
+                        collaborative: false,
+                        name: "Playlist 1"
+                    },
+                    {
+                        id: "playlistId 2",
+                        public: false,
+                        collaborative: true,
+                        name: "Playlist 2"
+                    }
+                ]
+            }
+            axios.get.mockResolvedValueOnce({ data: mockPlaylists });
+
+            // Act
+            const result = await getPlaylists();
+
+            // Assert
+            expect(result).toBe(mockPlaylists);
+            expect(result.items).toHaveLength(2);
+
+            expect(axios.get).toHaveBeenCalledTimes(1);
+            expect(getAuthHeaders).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
Only added happy path tests for now, as we need to handle errors better in `spotifyService.js` before any edge case unit tests will work. Still need happy path tests for `refreshToken`, `createPlaylist`, and `addTracksToPlaylist` functions.